### PR TITLE
Fix behaviour of permission 'minecraft.bypass.whitelist'

### DIFF
--- a/src/main/java/me/drex/vanillapermissions/mixin/cached_permission/bypass/whitelist/DedicatedPlayerListMixin.java
+++ b/src/main/java/me/drex/vanillapermissions/mixin/cached_permission/bypass/whitelist/DedicatedPlayerListMixin.java
@@ -16,7 +16,10 @@ public abstract class DedicatedPlayerListMixin {
         at = @At("RETURN")
     )
     public boolean addBypassWhitelistPermission(boolean original, GameProfile gameProfile) {
-        return JoinCache.getCachedPermissions(gameProfile.getId(), Permission.BYPASS_WHITELIST).orElse(original);
+        if(original) {
+            return true;
+        }
+        return JoinCache.getCachedPermissions(gameProfile.getId(), Permission.BYPASS_WHITELIST).orElse(false);
     }
 
 }


### PR DESCRIPTION
- previously, users could not join if this permission was set to 'false'
- this happened even if the user was explictly whitelisted

Fixes #27 