### PR TITLE
feat: fine-grained selector permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Fine-grained selector permission.
 
 ## [0.2.10] - 2025-06-19
 ### Fixed
@@ -48,6 +50,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Using wrong fallback command node requirement
+
+### Changed
+- `minecraft.command.<command>.*` are granted by default
 
 ## [0.2.1] - 2023-07-01
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -8,40 +8,147 @@ This mod adds permission checks into vanilla, to allow for full permission custo
 
 ## Permissions
 
-| Permission                                                                 	                | Description                                                                     	 |
-|---------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------|
-| `minecraft.adminbroadcast.receive`                                         	                | Receive command feedback                                                        	 |
-| `minecraft.bypass.spawn-protection`                                        	                | Build inside spawn protection                                                   	 |
-| `minecraft.bypass.force-gamemode`                                          	                | Bypass forced gamemode                                                          	 |
-| `minecraft.bypass.move-speed.player`                                       	                | Bypass "Player moved too fast"                                                  	 |
-| `minecraft.bypass.move-speed.vehicle.<entity>`                             	                | Bypass "Player moved too fast", while riding an `entity` (e.g `minecraft.boat`) 	 |
-| `minecraft.bypass.chat-speed`                                              	                | Bypass chat kick, when sending messages / commands to quick                     	 |
-| `minecraft.bypass.whitelist`                                               	                | Bypass server whitelist                                                         	 |
-| `minecraft.bypass.player-limit`                                            	                | Bypass server player limit                                                      	 |
-| `minecraft.command.<command>`                                              	                | Command permissions, see [commands](#commands) for more information             	 |
-| `minecraft.debug_stick.use.<block>`                                        	                | Use debug stick on `block` (e.g. `minecraft.oak_trapdoor`)                      	 |
-| `minecraft.debug_chart`                                        	                            | View debug chart                      	                                           |
-| `minecraft.<query/load>.<entity/block>`                                    	                | Place blocks with nbt data and use debug commands                               	 |
-| `minecraft.operator_block.<command_block/jigsaw/structure_block>.<place/view/edit/break>` 	 | Place, view, edit and break operator blocks.                                    	 |
-| `minecraft.selector`                                                       	                | Use entity selectors in commands                                                	 |
+| Permission                                                                                | Description                                                                                 |
+|-------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
+| `minecraft.adminbroadcast.receive`                                                        | Receive command feedback                                                                    |
+| `minecraft.bypass.spawn-protection`                                                       | Build inside spawn protection                                                               |
+| `minecraft.bypass.force-gamemode`                                                         | Bypass forced gamemode                                                                      |
+| `minecraft.bypass.move-speed.player`                                                      | Bypass "Player moved too fast"                                                              |
+| `minecraft.bypass.move-speed.vehicle.<entity>`                                            | Bypass "Player moved too fast", while riding an `entity` (e.g `minecraft.boat`)             |
+| `minecraft.bypass.chat-speed`                                                             | Bypass chat kick, when sending messages / commands to quick                                 |
+| `minecraft.bypass.whitelist`                                                              | Bypass server whitelist                                                                     |
+| `minecraft.bypass.player-limit`                                                           | Bypass server player limit                                                                  |
+| [`minecraft.command.<command>`](#commands)                                                | Command permissions, see [commands](#commands) for more information                         |
+| `minecraft.debug_stick.use.<block>`                                                       | Use debug stick on `block` (e.g. `minecraft.oak_trapdoor`)                                  |
+| `minecraft.debug_chart`                                                                   | View debug chart                                                                            |
+| `minecraft.<query/load>.<entity/block>`                                                   | Place blocks with nbt data and use debug commands                                           |
+| `minecraft.operator_block.<command_block/jigsaw/structure_block>.<place/view/edit/break>` | Place, view, edit and break operator blocks.                                                |
+| `minecraft.selector`                                                                      | Use entity selectors in commands                                                            |
+| [`minecraft.selector.entity.<command>.<selector>`](#selectors)                            | Allow selecting [non-player entities](#scope-control) using the `selector` within `command` |
+| [`minecraft.selector.player.<command>.<selector>`](#selectors)                            | Allow selecting [nonself players](#scope-control) using the `selector` within `command`     |
+| [`minecraft.selector.self.<command>.<selector>`](#selectors)                              | Allow selecting [self](#scope-control) using the `selector` within `command`                |
+
+## Meta
+
+Also sometimes referred to as "options" or "variables".
+
+Incorrect types are considered undefined values.
+
+| Meta                                                           | Type      | Description                                                                                                      |
+|----------------------------------------------------------------|-----------|------------------------------------------------------------------------------------------------------------------|
+| [`minecraft.selector.limit.<command>.<selector>`](#selectors)  | `Integer` | [Limit the maximum number](#entity-limit) of entities that can be selected using the `selector` within `command` |
+| [`minecraft.selector.weight.<command>.<selector>`](#selectors) | `Integer` | Selector weight, see [selection weight](#selection-weight) for more infomation                                   |
 
 ## Commands
 
-This mod uses [Brigadier's](https://github.com/Mojang/brigadier) node-based permission system. Each command is made up of multiple nodes, and each node has its own permission.
+This mod uses [Brigadier's](https://github.com/Mojang/brigadier) node-based permission system. Each command is made up
+of multiple nodes, and each node has its own permission.
 
 For example, the `/gamemode` command:
 - The root command node (`/gamemode`) requires minecraft.command.gamemode.
-- Sub-nodes like `survival`, `creative`, etc., use `minecraft.command.gamemode.survival`, `minecraft.command.gamemode.creative`, and so on.
+- Sub-nodes like `survival`, `creative`, etc., use `minecraft.command.gamemode.survival`,
+  `minecraft.command.gamemode.creative`, and so on.
 
-In vanilla Minecraft, only the **root node** has a permission check (e.g. OP level 2). Once a player has access to that root node, **all sub-nodes are considered unlocked by default**.
+In vanilla Minecraft, only the **root node** has a permission check (e.g. OP level 2). Once a player has access to that
+root node, **all sub-nodes are considered unlocked by default**.
 
 If you want finer control, you can manually restrict sub-nodes by denying their specific permissions.
 
-For example: 
-- Allow `minecraft.command.gamemode`
-- Deny `minecraft.command.gamemode.creative` and `minecraft.command.gamemode.spectator`
+#### Example
 
-This allows players to use `/gamemode` but restricts them to only the allowed sub-options (e.g., survival and adventure).
+```yml
+- Allow:
+  minecraft.command.gamemode
+- Deny:
+  minecraft.command.gamemode.creative
+  minecraft.command.gamemode.spectator
+```
+
+This allows players to use `/gamemode` but restricts them to only the allowed sub-options
+(e.g., survival and adventure).
+
+## Selectors
+
+Command blocks and datapacks bypass all selector permission checks.
+
+By default, granting `minecraft.selector` allows players to use any selector in commands they have access to.
+
+Fine-grained permission control operates as follows. Note that this mod restricts based on **selection results**, not
+raw selector syntax. Using player names, UUIDs, or selectors like `@e` are equivalent if they produce identical
+results.
+
+### Value of `selector`
+
+Defined in the *Arguments* section of each command's Minecraft Wiki page.
+
+For example, the [`/teleport`](https://minecraft.wiki/w/Commands/teleport#Arguments 'Minecraft Wiki') command uses
+`<targets>` and `<destination>` as selectors.
+
+### Scope Control
+
+Use these permissions to define selector scope:
+
+- `minecraft.selector.entity.<command>.<selector>`
+- `minecraft.selector.player.<command>.<selector>`
+- `minecraft.selector.self.<command>.<selector>`
+
+Commands fail if a player attempts to select unauthorized entities.
+
+#### Example
+
+```yml
+- Allow:
+  minecraft.command.teleport
+  minecraft.selector
+  minecraft.selector.self.teleport.targets
+  minecraft.selector.entity.teleport.targets
+  minecraft.selector.self.teleport.destination
+  minecraft.selector.player.teleport.destination
+- Deny:
+  minecraft.selector.*
+```
+
+Players may teleport themselves (`self` for `targets`) or non-player entities (`entity` for `targets`) to themselves
+(`self` for `destination`) or nonself players (`player` for `destination`).
+
+### Entity Limit
+
+Set meta `minecraft.selector.limit.<command>.<selector>` to restrict the maximum number of entities selectable via a
+given selector.
+
+No limit is applied if this meta is unset.
+
+### Selection Weight
+
+Controlled by meta `minecraft.selector.weight.<command>.<selector>`.
+
+Entities without weight settings can always select any target and be selected by any selector. When both entities have
+weight values, a selector can only select targets whose weight is `less than or equal` to its own.
+
+#### Example
+
+```yml
+# Global permissions
+- Allow:
+  minecraft.command.gamemode
+  minecraft.selector
+  minecraft.selector.self.gamemode.target
+  minecraft.selector.player.gamemode.target
+- Deny:
+  minecraft.selector.*
+# Player-specific metadata
+Player1: minecraft.selector.weight.gamemode.target = 7
+Player2: minecraft.selector.weight.gamemode.target = -1
+Player3: minecraft.selector.weight.gamemode.target = 7
+Player4: (no weight set)
+```
+
+| Player  | Can modify gamemode of   | Reason                                                                     |
+|---------|--------------------------|----------------------------------------------------------------------------|
+| Player1 | All players              | Weight ($7$) ≥ all others' weights                                         |
+| Player2 | Only Player2 and Player4 | Weight ($-1$) < Player1/Player3 ($7$)<br>No weight restriction for Player4 |
+| Player3 | All players              | Weight ($7$) ≥ all others' weights                                         |
+| Player4 | All players              | No weight restriction → unrestricted access                                |
 
 ## Quality of Life
 

--- a/src/main/java/me/drex/vanillapermissions/mixin/selector/EntityArgumentMixin.java
+++ b/src/main/java/me/drex/vanillapermissions/mixin/selector/EntityArgumentMixin.java
@@ -1,0 +1,85 @@
+package me.drex.vanillapermissions.mixin.selector;
+
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import me.drex.vanillapermissions.util.Permission;
+import me.lucko.fabric.api.permissions.v0.Permissions;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.arguments.EntityArgument;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Entity;
+import java.util.Collection;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(EntityArgument.class)
+public abstract class EntityArgumentMixin {
+
+    private static CommandSyntaxException NotAllowedException = EntityArgument.ERROR_SELECTORS_NOT_ALLOWED.create();
+
+    private static boolean canSelectEntity(CommandSourceStack source, String root, String selector) {
+        return Permissions.check(source, Permission.SELECTOR_ENTITY.formatted(root, selector), true);
+    }
+
+    private static boolean canSelectPlayer(CommandSourceStack source, String root, String selector) {
+        return Permissions.check(source, Permission.SELECTOR_PLAYER.formatted(root, selector), true);
+    }
+
+    private static boolean canSelectSelf(CommandSourceStack source, String root, String selector) {
+        return Permissions.check(source, Permission.SELECTOR_SELF.formatted(root, selector), true);
+    }
+
+    @Inject(
+        method = {
+            "getEntity",
+            "getPlayer",
+        },
+        at = @At("RETURN")
+    )
+    private static void addEntityPermission(CommandContext<CommandSourceStack> commandContext, String string, CallbackInfoReturnable<Entity> cir) throws CommandSyntaxException {
+        var source = commandContext.getSource();
+        if (!source.isPlayer()) return;
+
+        var root = commandContext.getRootNode().getName();
+        if (canSelectEntity(source, root, string)) return;
+
+        var selected = cir.getReturnValue();
+        if (!(selected instanceof ServerPlayer)) throw NotAllowedException;
+
+        if (canSelectPlayer(source, root, string) || source.getPlayer() == selected && canSelectSelf(source, root, string)) return;
+
+        throw NotAllowedException;
+    }
+
+    @Inject(
+        method = {
+            "getEntities",
+            "getOptionalEntities",
+            "getPlayers",
+            "getOptionalPlayers",
+        },
+        at = @At("RETURN")
+    )
+    private static void addEntitiesPermission(CommandContext<CommandSourceStack> commandContext, String string, CallbackInfoReturnable<Collection<Entity>> cir) throws CommandSyntaxException {
+        var source = commandContext.getSource();
+        if (!source.isPlayer()) return;
+
+        var root = commandContext.getRootNode().getName();
+        if (canSelectEntity(source, root, string)) return;
+
+        var self = source.getPlayer();
+        var selfOnly = true;
+        for (var selected : cir.getReturnValue()) {
+            if (!(selected instanceof ServerPlayer)) throw NotAllowedException;
+            if (selected != self) {
+                selfOnly = false;
+            }
+        }
+
+        if (canSelectPlayer(source, root, string) || selfOnly && canSelectSelf(source, root, string)) return;
+
+        throw NotAllowedException;
+    }
+}

--- a/src/main/java/me/drex/vanillapermissions/mixin/selector/EntityArgumentMixin.java
+++ b/src/main/java/me/drex/vanillapermissions/mixin/selector/EntityArgumentMixin.java
@@ -3,32 +3,62 @@ package me.drex.vanillapermissions.mixin.selector;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import me.drex.vanillapermissions.util.Permission;
+import me.lucko.fabric.api.permissions.v0.Options;
 import me.lucko.fabric.api.permissions.v0.Permissions;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.arguments.EntityArgument;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.Entity;
-import java.util.Collection;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import java.util.Collection;
+import java.util.Collections;
+
 @Mixin(EntityArgument.class)
 public abstract class EntityArgumentMixin {
 
-    private static CommandSyntaxException NotAllowedException = EntityArgument.ERROR_SELECTORS_NOT_ALLOWED.create();
+    private static void addSelectorPermission(CommandContext<CommandSourceStack> context, String selector, Collection<Entity> selected) throws CommandSyntaxException {
+        var source = context.getSource();
+        if (!source.isPlayer()) return;
 
-    private static boolean canSelectEntity(CommandSourceStack source, String root, String selector) {
-        return Permissions.check(source, Permission.SELECTOR_ENTITY.formatted(root, selector), true);
-    }
+        var root = context.getRootNode().getName();
+        var limit = Options.get(source, Permission.SELECTOR_LIMIT.formatted(root, selector), Integer::parseInt);
+        if (limit.isPresent() && limit.get() < selected.size()) throw EntityArgument.ERROR_SELECTORS_NOT_ALLOWED.create();
 
-    private static boolean canSelectPlayer(CommandSourceStack source, String root, String selector) {
-        return Permissions.check(source, Permission.SELECTOR_PLAYER.formatted(root, selector), true);
-    }
+        var weight = Permission.SELECTOR_WEIGHT.formatted(root, selector);
+        var sourceWeight = Options.get(source, weight, Integer::parseInt);
 
-    private static boolean canSelectSelf(CommandSourceStack source, String root, String selector) {
-        return Permissions.check(source, Permission.SELECTOR_SELF.formatted(root, selector), true);
+        var sourceWeightPresent = sourceWeight.isPresent();
+        var sourceWeightValue = 0;
+
+        if (sourceWeightPresent) {
+            sourceWeightValue = sourceWeight.get();
+        }
+
+        var entity = Permissions.check(source, Permission.SELECTOR_ENTITY.formatted(root, selector), true);
+        var player = Permissions.check(source, Permission.SELECTOR_PLAYER.formatted(root, selector), true);
+        var self = Permissions.check(source, Permission.SELECTOR_SELF.formatted(root, selector), true);
+
+        var sourcePlayer = source.getPlayer();
+        for (var selectedEntity : selected) {
+            if (selectedEntity instanceof ServerPlayer) {
+                if (selectedEntity == sourcePlayer) {
+                    if (!self) throw EntityArgument.ERROR_SELECTORS_NOT_ALLOWED.create();
+                } else {
+                    if (!player) throw EntityArgument.ERROR_SELECTORS_NOT_ALLOWED.create();
+                }
+            } else {
+                if (!entity) throw EntityArgument.ERROR_SELECTORS_NOT_ALLOWED.create();
+            }
+
+            if (sourceWeightPresent) {
+                var selectedWeight = Options.get(selectedEntity, weight, Integer::parseInt);
+                if (selectedWeight.isPresent() && selectedWeight.get() > sourceWeightValue) throw EntityArgument.ERROR_SELECTORS_NOT_ALLOWED.create();
+            }
+        }
     }
 
     @Inject(
@@ -39,18 +69,7 @@ public abstract class EntityArgumentMixin {
         at = @At("RETURN")
     )
     private static void addEntityPermission(CommandContext<CommandSourceStack> commandContext, String string, CallbackInfoReturnable<Entity> cir) throws CommandSyntaxException {
-        var source = commandContext.getSource();
-        if (!source.isPlayer()) return;
-
-        var root = commandContext.getRootNode().getName();
-        if (canSelectEntity(source, root, string)) return;
-
-        var selected = cir.getReturnValue();
-        if (!(selected instanceof ServerPlayer)) throw NotAllowedException;
-
-        if (canSelectPlayer(source, root, string) || source.getPlayer() == selected && canSelectSelf(source, root, string)) return;
-
-        throw NotAllowedException;
+        addSelectorPermission(commandContext, string, Collections.singleton(cir.getReturnValue()));
     }
 
     @Inject(
@@ -63,23 +82,6 @@ public abstract class EntityArgumentMixin {
         at = @At("RETURN")
     )
     private static void addEntitiesPermission(CommandContext<CommandSourceStack> commandContext, String string, CallbackInfoReturnable<Collection<Entity>> cir) throws CommandSyntaxException {
-        var source = commandContext.getSource();
-        if (!source.isPlayer()) return;
-
-        var root = commandContext.getRootNode().getName();
-        if (canSelectEntity(source, root, string)) return;
-
-        var self = source.getPlayer();
-        var selfOnly = true;
-        for (var selected : cir.getReturnValue()) {
-            if (!(selected instanceof ServerPlayer)) throw NotAllowedException;
-            if (selected != self) {
-                selfOnly = false;
-            }
-        }
-
-        if (canSelectPlayer(source, root, string) || selfOnly && canSelectSelf(source, root, string)) return;
-
-        throw NotAllowedException;
+        addSelectorPermission(commandContext, string, cir.getReturnValue());
     }
 }

--- a/src/main/java/me/drex/vanillapermissions/util/Permission.java
+++ b/src/main/java/me/drex/vanillapermissions/util/Permission.java
@@ -24,9 +24,11 @@ public class Permission {
     public static final String OPERATOR_BLOCK_EDIT = permission("operator_block.%s.edit");
     public static final String OPERATOR_BLOCK_BREAK = permission("operator_block.%s.break");
     public static final String SELECTOR = permission("selector");
-    public static final String SELECTOR_ENTITY = permission("selector.%s.%s.entity");
-    public static final String SELECTOR_PLAYER = permission("selector.%s.%s.player");
-    public static final String SELECTOR_SELF = permission("selector.%s.%s.self");
+    public static final String SELECTOR_ENTITY = permission("selector.entity.%s.%s");
+    public static final String SELECTOR_PLAYER = permission("selector.player.%s.%s");
+    public static final String SELECTOR_SELF = permission("selector.self.%s.%s");
+    public static final String SELECTOR_LIMIT = permission("selector.limit.%s.%s");
+    public static final String SELECTOR_WEIGHT = permission("selector.weight.%s.%s");
 
     protected static String permission(String permission) {
         return build(ResourceLocation.DEFAULT_NAMESPACE, permission);

--- a/src/main/java/me/drex/vanillapermissions/util/Permission.java
+++ b/src/main/java/me/drex/vanillapermissions/util/Permission.java
@@ -24,6 +24,9 @@ public class Permission {
     public static final String OPERATOR_BLOCK_EDIT = permission("operator_block.%s.edit");
     public static final String OPERATOR_BLOCK_BREAK = permission("operator_block.%s.break");
     public static final String SELECTOR = permission("selector");
+    public static final String SELECTOR_ENTITY = permission("selector.%s.%s.entity");
+    public static final String SELECTOR_PLAYER = permission("selector.%s.%s.player");
+    public static final String SELECTOR_SELF = permission("selector.%s.%s.self");
 
     protected static String permission(String permission) {
         return build(ResourceLocation.DEFAULT_NAMESPACE, permission);

--- a/src/main/resources/vanilla-permissions.mixins.json
+++ b/src/main/resources/vanilla-permissions.mixins.json
@@ -35,6 +35,7 @@
     "operator_blocks.ServerPlayerGameModeMixin",
     "operator_blocks.SetJigsawBlockMixin",
     "operator_blocks.StructureBlockEntityMixin",
+    "selector.EntityArgumentMixin",
     "selector.EntitySelectorMixin",
     "selector.EntitySelectorParserMixin"
   ],


### PR DESCRIPTION
1. Mixin `EntityArgument` to implement fine-grained selector permission.
2. Make detailed introduction in `README.md`.
3. Update `README.md` and `CHANGELOG.md`.

<details>
<summary>Details, also available in <code>README.md</code></summary>
<p>

## Permissions

| Permission                                                                                | Description                                                                                 |
|-------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
| ...                                                                                       | ...                                                                                         |
| [`minecraft.selector.entity.<command>.<selector>`](#selectors)                            | Allow selecting [non-player entities](#scope-control) using the `selector` within `command` |
| [`minecraft.selector.player.<command>.<selector>`](#selectors)                            | Allow selecting [nonself players](#scope-control) using the `selector` within `command`     |
| [`minecraft.selector.self.<command>.<selector>`](#selectors)                              | Allow selecting [self](#scope-control) using the `selector` within `command`                |

## Meta

Also sometimes referred to as "options" or "variables".

Incorrect types are considered undefined values.

| Meta                                                           | Type      | Description                                                                                                      |
|----------------------------------------------------------------|-----------|------------------------------------------------------------------------------------------------------------------|
| [`minecraft.selector.limit.<command>.<selector>`](#selectors)  | `Integer` | [Limit the maximum number](#entity-limit) of entities that can be selected using the `selector` within `command` |
| [`minecraft.selector.weight.<command>.<selector>`](#selectors) | `Integer` | Selector weight, see [selection weight](#selection-weight) for more infomation                                   |

---

## Selectors

Command blocks and datapacks bypass all selector permission checks.

By default, granting `minecraft.selector` allows players to use any selector in commands they have access to.

Fine-grained permission control operates as follows. Note that this mod restricts based on **selection results**, not
raw selector syntax. Using player names, UUIDs, or selectors like `@e` are equivalent if they produce identical
results.

### Value of `selector`

Defined in the *Arguments* section of each command's Minecraft Wiki page.

For example, the [`/teleport`](https://minecraft.wiki/w/Commands/teleport#Arguments 'Minecraft Wiki') command uses
`<targets>` and `<destination>` as selectors.

### Scope Control

Use these permissions to define selector scope:

- `minecraft.selector.entity.<command>.<selector>`
- `minecraft.selector.player.<command>.<selector>`
- `minecraft.selector.self.<command>.<selector>`

Commands fail if a player attempts to select unauthorized entities.

#### Example

```yml
- Allow:
  minecraft.command.teleport
  minecraft.selector
  minecraft.selector.self.teleport.targets
  minecraft.selector.entity.teleport.targets
  minecraft.selector.self.teleport.destination
  minecraft.selector.player.teleport.destination
- Deny:
  minecraft.selector.*
```

Players may teleport themselves (`self` for `targets`) or non-player entities (`entity` for `targets`) to themselves
(`self` for `destination`) or nonself players (`player` for `destination`).

### Entity Limit

Set meta `minecraft.selector.limit.<command>.<selector>` to restrict the maximum number of entities selectable via a
given selector.

No limit is applied if this meta is unset.

### Selection Weight

Controlled by meta `minecraft.selector.weight.<command>.<selector>`.

Entities without weight settings can always select any target and be selected by any selector. When both entities have
weight values, a selector can only select targets whose weight is `less than or equal` to its own.

#### Example

```yml
# Global permissions
- Allow:
  minecraft.command.gamemode
  minecraft.selector
  minecraft.selector.self.gamemode.target
  minecraft.selector.player.gamemode.target
- Deny:
  minecraft.selector.*
# Player-specific metadata
Player1: minecraft.selector.weight.gamemode.target = 7
Player2: minecraft.selector.weight.gamemode.target = -1
Player3: minecraft.selector.weight.gamemode.target = 7
Player4: (no weight set)
```

| Player  | Can modify gamemode of   | Reason                                                                     |
|---------|--------------------------|----------------------------------------------------------------------------|
| Player1 | All players              | Weight ($7$) ≥ all others' weights                                         |
| Player2 | Only Player2 and Player4 | Weight ($-1$) < Player1/Player3 ($7$)<br>No weight restriction for Player4 |
| Player3 | All players              | Weight ($7$) ≥ all others' weights                                         |
| Player4 | All players              | No weight restriction → unrestricted access                                |

</p>
</details> 

> BTW, I updated #30 stuff in `CHANGELOG.md`, as you only updated it in `README.md`.