### PR TITLE
perf: improve command tree search performance on initialization

### DIFF
--- a/src/main/java/me/drex/vanillapermissions/VanillaPermissionsMod.java
+++ b/src/main/java/me/drex/vanillapermissions/VanillaPermissionsMod.java
@@ -37,12 +37,12 @@ public class VanillaPermissionsMod implements ModInitializer {
     }
 
     @SuppressWarnings("unchecked")
-    private void alterCommandChildNode(String path, CommandNode<CommandSourceStack> commandNode) {
-        LOGGER.debug("Alter command node {}", path);
+    private void alterCommandChildNode(String name, CommandNode<CommandSourceStack> commandNode) {
+        LOGGER.debug("Alter command node {}", name);
         for (CommandNode<CommandSourceStack> child : commandNode.getChildren()) {
-            alterCommandChildNode(build(path, child.getName()), child);
+            alterCommandChildNode(build(name, child.getName()), child);
         }
-        ((CommandNodeAccessor<CommandSourceStack>) commandNode).setRequirement(createPredicate(path, commandNode.getRequirement()));
+        ((CommandNodeAccessor<CommandSourceStack>) commandNode).setRequirement(createPredicate(name, commandNode.getRequirement()));
     }
 
     private Predicate<CommandSourceStack> createPredicate(String name, Predicate<CommandSourceStack> fallback) {


### PR DESCRIPTION
Let's talk about something easy. :)
# `dispatcher.getPath` is unreliable and inefficient
As documented, `dispatcher.getPath`:
> There may theoretically be multiple paths to a node on the tree, especially with the use of forking or redirecting. As such, this method makes no guarantees about which path it finds. It will not look at forks or redirects, and find the first instance of the target node on the tree.

While functional as in Minecraft 1.21.6, this method provides **no guarantees** about path accuracy due to its inherent limitations.

Plus, each call to `dispatcher.getPath` scans the entire command tree, resulting in $O(n)$ time complexity. During mod initialization, we call this method $O(n)$ times while traversing the tree. This creates an $O(n^2)$ complexity bottleneck.

# What did I do
Simpler and more robust: Instead of passing the `dispatcher` during recursion, we now propagate the `path` string directly.
* Eliminates reliance on `dispatcher.getPath`
* Ensures deterministic path resolution
* Reduces time complexity to $O(n)$ during initialization