### PR TITLE
fix: game rule menu support

### DIFF
--- a/src/main/java/me/drex/vanillapermissions/mixin/command/ServerGamePacketListenerImplMixin.java
+++ b/src/main/java/me/drex/vanillapermissions/mixin/command/ServerGamePacketListenerImplMixin.java
@@ -8,6 +8,8 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
 import me.drex.vanillapermissions.util.Permission;
 import me.lucko.fabric.api.permissions.v0.Permissions;
@@ -70,14 +72,11 @@ public abstract class ServerGamePacketListenerImplMixin {
     }
 
     //? if > 1.21.11 {
-    @Shadow
-    public abstract void setGameRuleValue(GameRules rules, GameRule<?> rule, String value);
-
     @ModifyExpressionValue(
         method = "sendGameRuleValues",
         at = @At(
             value = "INVOKE",
-            target = "hasPermission"
+            target = "Lnet/minecraft/server/permissions/PermissionSet;hasPermission(Lnet/minecraft/server/permissions/Permission;)Z"
         )
     )
     public boolean readGameRulePermissionCheck(boolean original) {
@@ -88,7 +87,7 @@ public abstract class ServerGamePacketListenerImplMixin {
         method = "sendGameRuleValues",
         at = @At(
             value = "INVOKE",
-            target = "availableRules"
+            target = "Lnet/minecraft/world/level/gamerules/GameRules;availableRules()Ljava/util/stream/Stream;"
         )
     )
     public <T> Stream<GameRule<T>> readGameRuleFilter(Stream<GameRule<T>> rules) {
@@ -99,45 +98,46 @@ public abstract class ServerGamePacketListenerImplMixin {
         method = "handleSetGameRule",
         at = @At(
             value = "INVOKE",
-            target = "hasPermission"
+            target = "Lnet/minecraft/server/permissions/PermissionSet;hasPermission(Lnet/minecraft/server/permissions/Permission;)Z"
         )
     )
     public boolean changeGameRulePermissionCheck(boolean original) {
         return true;
     }
 
-    @Redirect(
+    @WrapOperation(
         method = "handleSetGameRule",
         at = @At(
             value = "INVOKE",
-            target = "setGameRuleValue"
+            target = "Lnet/minecraft/server/network/ServerGamePacketListenerImpl;setGameRuleValue(Lnet/minecraft/world/level/gamerules/GameRules;Lnet/minecraft/world/level/gamerules/GameRule;Ljava/lang/String;)V"
         )
     )
-    public void changeGameRuleFilter(ServerGamePacketListenerImpl instance, GameRules rules, GameRule<?> rule, String value) {
-        if (!checkPermission("gamerule " + rule + " " + value)) return;
-        setGameRuleValue(rules, rule, value);
+    public void changeGameRuleFilter(
+        ServerGamePacketListenerImpl instance, GameRules rules, GameRule<?> rule, String value, Operation<Void> original
+    ) {
+        if (checkPermission("gamerule " + rule + " " + value)) {
+            original.call(instance, rules, rule, value);
+        }
     }
 
     @ModifyArg(
         method = "broadcastGameRuleChangeToOperators",
         at = @At(
             value = "INVOKE",
-            target = "filter"
+            target = "Ljava/util/stream/Stream;filter(Ljava/util/function/Predicate;)Ljava/util/stream/Stream;"
         )
     )
     public Predicate<ServerPlayer> addAdminBroadcastReceivePermission(Predicate<ServerPlayer> original) {
-        return player -> switch (Permissions.getPermissionValue(player, Permission.ADMIN_BROADCAST_RECEIVE)) {
-            case TRUE -> true;
-            case FALSE -> false;
-            default -> original.test(player);
-        };
+        return player -> Permissions.getPermissionValue(player, Permission.ADMIN_BROADCAST_RECEIVE)
+            .orElseGet(() -> original.test(player));
     }
     //? }
 
     @Unique
     private boolean checkPermission(String command) {
-        var parsed = player.level().getServer().getCommands().getDispatcher().parse(command, player.createCommandSourceStack());
-        return parsed != null && getParseException(parsed) == null;
+        var parsed = player.level().getServer().getCommands().getDispatcher()
+            .parse(command, player.createCommandSourceStack());
+        return getParseException(parsed) == null;
     }
 }
 //?} else {

--- a/src/main/java/me/drex/vanillapermissions/mixin/command/ServerGamePacketListenerImplMixin.java
+++ b/src/main/java/me/drex/vanillapermissions/mixin/command/ServerGamePacketListenerImplMixin.java
@@ -24,6 +24,7 @@ import net.minecraft.world.level.gamerules.GameRules;
 //? }
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
@@ -129,6 +130,7 @@ public abstract class ServerGamePacketListenerImplMixin {
     }
     //? }
 
+    @Unique
     private boolean checkPermission(String command) {
         var parsed = player.level().getServer().getCommands().getDispatcher().parse(command, player.createCommandSourceStack());
         return parsed != null && getParseException(parsed) == null;

--- a/src/main/java/me/drex/vanillapermissions/mixin/command/ServerGamePacketListenerImplMixin.java
+++ b/src/main/java/me/drex/vanillapermissions/mixin/command/ServerGamePacketListenerImplMixin.java
@@ -2,25 +2,31 @@ package me.drex.vanillapermissions.mixin.command;
 
 //? if >= 1.21.6 {
 
+import static net.minecraft.commands.Commands.getParseException;
+
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.llamalad7.mixinextras.sugar.Local;
-import com.mojang.brigadier.ParseResults;
-import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import me.drex.vanillapermissions.util.Permission;
+import me.lucko.fabric.api.permissions.v0.Permissions;
 import net.minecraft.ChatFormatting;
-import net.minecraft.commands.CommandSourceStack;
-import net.minecraft.commands.Commands;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.game.ServerboundChangeGameModePacket;
-
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.network.ServerGamePacketListenerImpl;
 //? if > 1.21.10 {
 import net.minecraft.server.permissions.PermissionCheck;
 import net.minecraft.server.permissions.PermissionSet;
+import net.minecraft.world.level.gamerules.GameRule;
+import net.minecraft.world.level.gamerules.GameRules;
 //? }
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
@@ -47,12 +53,8 @@ public abstract class ServerGamePacketListenerImplMixin {
         /*ServerPlayer instance, int i,
         *///? }
         @Local(argsOnly = true) ServerboundChangeGameModePacket packet
-        ) {
-        var server = player.level().getServer();
-        Commands commands = server.getCommands();
-        ParseResults<CommandSourceStack> parseResults = commands.getDispatcher().parse("gamemode " + packet.mode().getName(), player.createCommandSourceStack());
-        CommandSyntaxException exception = Commands.getParseException(parseResults);
-        return exception == null;
+    ) {
+        return checkPermission("gamemode " + packet.mode().getName());
     }
 
     @Inject(
@@ -64,6 +66,72 @@ public abstract class ServerGamePacketListenerImplMixin {
     )
     public void sendFeedback(ServerboundChangeGameModePacket packet, CallbackInfo ci) {
         this.player.sendSystemMessage(Component.translatable("commands.help.failed").withStyle(ChatFormatting.RED));
+    }
+
+    //? if > 1.21.11 {
+    @Shadow
+    public abstract void setGameRuleValue(GameRules rules, GameRule<?> rule, String value);
+
+    @ModifyExpressionValue(
+        method = "sendGameRuleValues",
+        at = @At(
+            value = "INVOKE",
+            target = "hasPermission"
+        )
+    )
+    public boolean readGameRulePermissionCheck(boolean original) {
+        return true;
+    }
+
+    @ModifyExpressionValue(
+        method = "sendGameRuleValues",
+        at = @At(
+            value = "INVOKE",
+            target = "availableRules"
+        )
+    )
+    public <T> Stream<GameRule<T>> readGameRuleFilter(Stream<GameRule<T>> rules) {
+        return rules.filter(rule -> checkPermission("gamerule " + rule));
+    }
+
+    @ModifyExpressionValue(
+        method = "handleSetGameRule",
+        at = @At(
+            value = "INVOKE",
+            target = "hasPermission"
+        )
+    )
+    public boolean changeGameRulePermissionCheck(boolean original) {
+        return true;
+    }
+
+    @Redirect(
+        method = "handleSetGameRule",
+        at = @At(
+            value = "INVOKE",
+            target = "setGameRuleValue"
+        )
+    )
+    public void changeGameRuleFilter(ServerGamePacketListenerImpl instance, GameRules rules, GameRule<?> rule, String value) {
+        if (!checkPermission("gamerule " + rule + " " + value)) return;
+        setGameRuleValue(rules, rule, value);
+    }
+
+    @ModifyArg(
+        method = "broadcastGameRuleChangeToOperators",
+        at = @At(
+            value = "INVOKE",
+            target = "filter"
+        )
+    )
+    public Predicate<ServerPlayer> addAdminBroadcastReceivePermission(Predicate<ServerPlayer> original) {
+        return player -> Permissions.check(player, Permission.ADMIN_BROADCAST_RECEIVE, original.test(player));
+    }
+    //? }
+
+    private boolean checkPermission(String command) {
+        var parsed = player.level().getServer().getCommands().getDispatcher().parse(command, player.createCommandSourceStack());
+        return parsed != null && getParseException(parsed) == null;
     }
 }
 //?} else {

--- a/src/main/java/me/drex/vanillapermissions/mixin/command/ServerGamePacketListenerImplMixin.java
+++ b/src/main/java/me/drex/vanillapermissions/mixin/command/ServerGamePacketListenerImplMixin.java
@@ -126,7 +126,11 @@ public abstract class ServerGamePacketListenerImplMixin {
         )
     )
     public Predicate<ServerPlayer> addAdminBroadcastReceivePermission(Predicate<ServerPlayer> original) {
-        return player -> Permissions.check(player, Permission.ADMIN_BROADCAST_RECEIVE, original.test(player));
+        return player -> switch (Permissions.getPermissionValue(player, Permission.ADMIN_BROADCAST_RECEIVE)) {
+            case TRUE -> true;
+            case FALSE -> false;
+            default -> original.test(player);
+        };
     }
     //? }
 


### PR DESCRIPTION
Hi, there. It's me again!

In version 26.1, a new screen called [World Options](https://minecraft.wiki/w/Options#World_Options), was added to the game. OPs can now modify gamerules via this GUI. However, *VanillaPermissions* does not support this menu. This PR fixes that issue.

All changes are implemented alongside the gamemode switch panel mixin, reusing its code.

### Modified:

1. Core of `changeGameModePermissionCheck` has been extracted to a private method `checkPermission`.

### New, for Minecraft > 1.21.11:

1. Always return the list of gamerules to players.
2. If a player has permission to read a specific gamerule (using `/gamerule foo`), that gamerule will be included in the list.
3. Always accept the list of gamerules sent from the player's changes.
4. If a player has permission to update a specific gamerule (using `/gamerule foo <value>`), that gamerule will be included in the list.
5. Any changes made via the GUI will be broadcast to players who have the `minecraft.adminbroadcast.receive` permission.